### PR TITLE
Dutch translation

### DIFF
--- a/imatchres.xml
+++ b/imatchres.xml
@@ -2389,6 +2389,7 @@
             <cmd resid="ID_VIEW_SHOW_APP_MANAGER">
                 <c xml:lang="en" hotkey="F9|Y" helptext="Show or hide the App Manager panel">App &amp;Manager</c>
                 <c xml:lang="de" hotkey="F9|Y" helptext="Anzeigen oder Verbergen des App-Manager Panels">&amp;App-Manager</c>
+				<c xml:lang="nl" hotkey="F9|Y" helptext="Toon of verberg het App Manager paneel">&amp;App-Manager</c>
             </cmd>
 			
 			<!-- Thumbnail Tooltips? (Toggles E > P > Application: Thumb Tips) -->
@@ -3029,6 +3030,7 @@
             <cmd resid="ID_CMD_FAVORITE_APP_ADD">
                 <c xml:lang="en" hotkey="" helptext="Add a new favorite for an app">New from &amp;App...</c>
                 <c xml:lang="de" hotkey="" helptext="Einen neuen Favoriten für eine App hinzufügen.">Neu von &amp;App...</c>
+				<c xml:lang="nl" hotkey="" helptext="Een nieuwe favoriet voor een App toevoegen">Nieuw vanuit &amp;App...</c>
             </cmd>
 			
             <!-- Favorites, Metadata Templates -->
@@ -3706,6 +3708,7 @@
 			<cmd resid="ID_CMD_APP_PANEL_COMBO" bmidx="-1">
                 <c xml:lang="en" helptext="Select an App">App</c>
                 <c xml:lang="de" helptext="Wählen Sie eine App aus">App</c>
+				<c xml:lang="nl" helptext="Selecteer een App">App</c>
             </cmd>
             
 			<cmd resid="ID_CMD_APP_PANEL_RELOAD" bmidx="1">
@@ -4980,11 +4983,13 @@
 			<cmd resid="ID_APP_RELEASE_NOTES" bmidx="3">
 				<c xml:lang="en" hotkey="" helptext="Opens the release notes page in your default browser.">&amp;Release Notes (Online)</c>
 				<c xml:lang="de" hotkey="" helptext="Öffnet die Versionsinformationen in Ihrem Browser.">Ve&amp;rsionsinformationen (Online)</c>
+				<c xml:lang="nl" hotkey="" helptext="Opent de realease notes in uw standaard browser.">&amp;Release Notes (Online)</c>
 			</cmd>
 
 			<cmd resid="ID_APP_DEVCENTER" bmidx="3">
-				<c xml:lang="en" hotkey="" helptext="Opens the IMatch Developer Center web site.">&amp;Developer Center (Online)</c>
+				<c xml:lang="en" hotkey="" helptext="Opens the IMatch Developer Center website.">&amp;Developer Center (Online)</c>
 				<c xml:lang="de" hotkey="" helptext="Öffnet die photools.com Developer Center Webseite.">&amp;Developer Center (Online)</c>
+				<c xml:lang="nl" hotkey="" helptext="Opent de IMatch Developer Center website.">&amp;Developer Center (Online)</c>				
 			</cmd>
 
 			<cmd resid="ID_APP_ORDER" bmidx="9">
@@ -6686,10 +6691,12 @@
 			<cmd resid="ID_CMD_FILE_THUMBSET_NEXT" desc="">
 				<c xml:lang="en" hotkey="Shift+Ctrl+VK_NEXT" helptext="Change the thumbnail to use for this video.">&amp;Next Frame</c>
 				<c xml:lang="de" hotkey="Shift+Ctrl+VK_NEXT" helptext="Das Vorschaubild für dieses Video ändern.">&amp;Nächtes Bild</c>
+				<c xml:lang="nl" hotkey="Shift+Ctrl+VK_NEXT" helptext="Wijzig de miniatuur voor deze video.">&amp;Volgende beeld</c>
 			</cmd>
 			<cmd resid="ID_CMD_FILE_THUMBSET_PREV" desc="">
 				<c xml:lang="en" hotkey="Shift+Ctrl+VK_PRIOR" helptext="Change the thumbnail to use for this video.">&amp;Previous Frame</c>
 				<c xml:lang="de" hotkey="Shift+Ctrl+VK_PRIOR" helptext="Das Vorschaubild für dieses Video ändern.">&amp;Vorhergehendes Bild</c>
+				<c xml:lang="nl" hotkey="Shift+Ctrl+VK_NEXT" helptext="Wijzig de miniatuur voor deze video.">&amp;Vorige beeld</c>
 			</cmd>
 		</command_group>
 
@@ -8444,6 +8451,7 @@
 			<cmd resid="ID_FILEWND_SHOWGROUPS_DIRECT_FILES_ONLY"  bmidx="11">
 				<c xml:lang="en" hotkey="" helptext="Show only the files directly assigned to the selected category. Don't include files in child categories.">Show only &amp;directly assigned files</c>
 				<c xml:lang="de" hotkey="" helptext="Zeige nur Dateien, die der ausgewählten Kategorie direkt zugewiesen wurden. Dateien in Kindkategorien nicht einschließen.">Nur &amp;direkt zugewiesene Dateien zeigen</c>
+				<c xml:lang="nl" hotkey="" helptext="Zoon alleen de direct aan deze categorie toegewezen bestanden. Bestanden in subcategoriën niet tonen.">Toon alleen &amp;direct toegewezen bestanden</c>
 			</cmd>
 
 		</command_group>
@@ -15837,6 +15845,7 @@
 				<name>
 					<n xml:lang="en">&amp;Video Options</n>
 					<n xml:lang="de">&amp;Video-Optionen</n>
+					<n xml:lang="nl">&amp;Video Opties</n>
 				</name>
 				<item>ID_CMD_FILE_THUMBSET_NEXT</item>
 				<item>ID_CMD_FILE_THUMBSET_PREV</item>
@@ -17969,10 +17978,13 @@
 			<property resid="app.imws.shfwebroot" desc="">
                 <name xml:lang="en">Root folder for apps</name>
                 <name xml:lang="de">Wurzelverzeichnis für Apps</name>
+				<name xml:lang="nl">Root maapvoot apps</name>
                 <desc xml:lang="en">The folder containing apps and scripts for IMatch.</desc>
                 <desc xml:lang="de">Dieses Verzeichnis enthält Apps und Skripte für IMatch.</desc>
+				<desc xml:lang="nl">The map waarin de apps en scripts voor IMatch staan.</desc>
                 <group xml:lang="en">Folders</group>
                 <group xml:lang="de">Verzeichnisse</group>
+				<group xml:lang="nl">Mappen</group>
             </property>
 			
             <property resid="app.shfpresets" desc="">
@@ -18815,6 +18827,7 @@
 			<property resid="app.ui.browserscale" desc="">
 				<name xml:lang="en">App Panel Scale</name>
 				<name xml:lang="de">App-Panel Skalierung</name>
+				<name xml:lang="nl">Scahaal van het App-paneel</name>
 				<group xml:lang="en">User Interface</group>
 				<group xml:lang="de">Benutzerschnittstelle</group>
 				<group xml:lang="fi">Käyttöliittymä</group>
@@ -18823,7 +18836,8 @@
 				<group xml:lang="pt">Interface do utilizador</group>
 				<group xml:lang="no">Brukergrensesnitt</group>
 				<desc xml:lang="en">This setting controls the scale factor used for App Panels, the App Manager and the Map Panel. Use this to adjust the size of text and images to your liking. The default value is 0, which means 100%. Use values smaller than 0 to reduce the scale and reduce the text size. Use values above 0 to increase the font size for better readability.</desc>
-				<desc xml:lang="de">Diese Einstellung kontrolliert den Skalierungsfaktor für App-Panels, den App Manager und das Map-Panel. Stellen Sie den Skalierungsfaktor nach Ihren Bedorfnissen ein. 0 bedeutet 100%. Werte kleiner 0 reduzieren die Schriftgröße, Werte größer als 0 stellen Schrift und Bilder größer dar.</desc>
+				<desc xml:lang="de">Diese Einstellung kontrolliert den Skalierungsfaktor für App-Panels, den App Manager und das Map-Panel. Stellen Sie den Skalierungsfaktor nach Ihren Bedarfnissen ein. 0 bedeutet 100%. Werte kleiner 0 reduzieren die Schriftgröße, Werte größer als 0 stellen Schrift und Bilder größer dar.</desc>
+				<desc xml:lang="nl">Deze instelling bepaalt the schalingsfactor voor de App-panelen, de App Manager en het kaart-paneel. Gebruik om de groote van tekst en afbeedlingen aan te passen aan uw smaak. De standaard waarde is 0, wat 100% betekent. Waarden kleiner dan 0 verkleinen de grootte, waarden groter dan 0 maken de grootte van tekst en afbeeldingen groter.</desc>
 			</property>
 		
 
@@ -19322,46 +19336,61 @@
 			<property resid="imws.enabled" >
 				<name xml:lang="en">IMWS enabled</name>
 				<name xml:lang="de">IMWS aktiviert</name>
+				<name xml:lang="nl">IMWS actief</name>
 				<desc xml:lang="en">If this setting is off, the embedded IMatch WebServices is disabled. No scripts or apps can work.</desc>
 				<desc xml:lang="de">Diese Einstellung bestimmt, ob der integrierte Webdienst in IMatch ausgeführt wird. Er wird für die Ausführung von Skripten und Apps benötigt.</desc>
+				<desc xml:lang="nl">Deze instelling bepaalt of de geïntegreerde IMatch Webservices worden uitgevoerd. Die zijn voor de uitvoering van scripts en Apps nodig.</desc>
 				<group xml:lang="en">Embedded IMatch WebServices</group>
 				<group xml:lang="de">Integrierte IMatch-Webdienste</group>
+				<group xml:lang="nl">Geïntegreerde IMatch WebServices</group>
 			</property>
 			
 			<property resid="imws.port" >
 				<name xml:lang="en">Port Number</name>
 				<name xml:lang="de">Port-Nummer</name>
+				<name xml:lang="nl">Poort nummer</name>
 				<desc xml:lang="en">The port number to use for IMWS. If the default port number is already in use on your system, select another number in the range 49152-65535.</desc>
 				<desc xml:lang="de">Die Port-Nummer, under der der integrierte Webdienst ereichbar ist. Wenn der Standard-Port auf Ihrem System bereits von einem anderen Dienst verwendet wird, wählen Sie einen freien Port im Bereich 49152-65535.</desc>
+				<desc xml:lang="nl">Het poortnummer dat voor IMWS wordt gebruikt. Als het standaardpoortnummer al in gebruik is op uw systeem, kiers dan een ander vrij nummer in de reeks 49152-65535.</desc>
 				<group xml:lang="en">Embedded IMatch WebServices</group>
 				<group xml:lang="de">Integrierte IMatch-Webdienste</group>
+				<group xml:lang="nl">Geïntegreerde IMatch WebServices</group>
 			</property>
 
 			<property resid="imws.documentroot" >
 				<name xml:lang="en">Document Root / App Folder</name>
 				<name xml:lang="de">Dokument- und App-Wurzelverzeichnis</name>
+				<name xml:lang="nl">Document Root / App map</name>
 				<desc xml:lang="en">This folder contains all scripts, documents and apps which should be accessible via the embedded IMatch WebServices. The IMatch App Manager also uses this folder to find the system and your apps.</desc>
 				<desc xml:lang="de">Dieses Verzeichnis enthält alle Skripte, Dokumente und Apps, die über den integrierten Webdienst erreichbar sein sollen. Der IMatch App-Manager durchsucht ebenfalls dieses Verzeichnis, um System- und benutzerdefinierte Skripte zu finden.</desc>
+				<desc xml:lang="nl">Deze map bevat alle scripts, documenten en apps die via de geïntegreerde IMatch WebServices bereikbaar zouden moeten zijn. Ookde IMatch App Manager gebruikt deze map om de systeem- en gebruikers apps te vinden.</desc>
 				<group xml:lang="en">Embedded IMatch WebServices</group>
 				<group xml:lang="de">Integrierte IMatch-Webdienste</group>
+				<group xml:lang="nl">Geïntegreerde IMatch WebServices</group>
 			</property>
 
 			<property resid="cef.debugport" >
 				<name xml:lang="en">Remote Debugging Port</name>
 				<name xml:lang="de">Remote-Debugging Port</name>
+				<name xml:lang="nl">Remote Debugging Poort</name>
 				<desc xml:lang="en">If this is 0, remote debugging of the embedded browser is disabled. Set this to a valid port number (e.g. 8080) to enable remote debugging.</desc>
 				<desc xml:lang="de">Ist dieser Wert 0, ist Remote-Debugging für den eingebetteten Web-Browsers deaktiviert. Tragen Sie eine gültige Port-Nummer (z.B. 8080) ein, um Remote-Debugging zu nutzen.</desc>
+				<desc xml:lang="nl">Als deze waarde op 0 staat, is remote debugging van de ingebouwd browser niet mogelijk. Voer een geldig poortnummer is (bv. 8080) om remote debugging te benutten.</desc>
 				<group xml:lang="en">Developer Options</group>
 				<group xml:lang="de">Entwickler-Optionen</group>
+				<group xml:lang="nl">Opties voor ontwikkelaars</group>
 			</property>
 
 			<property resid="cef.clearcache" >
 				<name xml:lang="en">Clear browser cache on exit</name>
 				<name xml:lang="de">Browser-Cache beim Beenden leeren</name>
+				<name xml:lang="nl">Browsercache leegmaken bij afsluiten</name>
 				<desc xml:lang="en">If this is enabled, IMatch clears the cache of the embedded browser when exiting. Use this option if there is a problem with the cache or the browser does not pick up changes done to files.</desc>
 				<desc xml:lang="de">Wenn diese Einstellung aktiviert ist, leert IMatch beim Schließen den Cache des integrierten Web-Browsers. Nutzen Sie dies temporär, wenn es ein Problem mit dem Cache gibt oder der Browser geänderte Dateien nicht erkennt.</desc>
+				<desc xml:lang="nl">Als deze otie geaktveerd is, zal IMatch de cache van de ingebouwde browser leeg maken bij afsluiten. Gebruik deze optie als er een probleem met de browser is of als de browser wijzigingen in bestanden niet herkent.</desc>
 				<group xml:lang="en">Developer Options</group>
 				<group xml:lang="de">Entwickler-Optionen</group>
+				<group xml:lang="nl">Opties voor ontwikkelaars</group>
 			</property>
 
 
@@ -28133,19 +28162,25 @@
 			<property resid="filewnd.ui.anim.enabled" desc="">
 				<name xml:lang="en">Animated previews for videos</name>
 				<name xml:lang="de">Animierte Vorschau von Videos</name>
+				<name xml:lang="nl">Geanimeerde previews voor videos</name>
 				<desc xml:lang="en">If this is enabled, the file window displays multiple frames for each video file when you move the mouse into a thumbnail panel.</desc>
 				<desc xml:lang="de">Aktivieren Sie diese Option, um animierte Vorschauen für Videos zu zeigen. Das Dateifenster zeigt diese Vorschauen, wenn Sie mit der Maus auf ein Vorschaubild zeigen.</desc>
+				<desc xml:lang="nl">Activeer deze optie, om een genaimeerde preview voor iedere video te zien, als u met de muis naar een miniatuur wijst.</desc>
 				<group xml:lang="en">Animation</group>
 				<group xml:lang="de">Animation</group>
+				<group xml:lang="nl">Animatie</group>
 			</property>
 
 			<property resid="filewnd.ui.anim.steptime" desc="">
 				<name xml:lang="en">Animation frame duration</name>
 				<name xml:lang="de">Anzeigedauer pro Bild</name>
+				<name xml:lang="nl">Animatieduur per frame</name>
 				<desc xml:lang="en">The time between individual animation frams in millseconds (1000ms = 1 second).</desc>
 				<desc xml:lang="de">Anzeigeduaer der einzelnen Bilder in Millisekunden (1000ms = 1 Sekunde).</desc>
+				<desc xml:lang="nl">De tijd tussen afzonderlijke animatie frames in milliseconden (1000ms = 1 second).</desc>
 				<group xml:lang="en">Animation</group>
 				<group xml:lang="de">Animation</group>
+				<group xml:lang="nl">Animatie</group>
 			</property>
 
 

--- a/imatchres_dlg.xml
+++ b/imatchres_dlg.xml
@@ -9908,9 +9908,11 @@
 		<dialog resid="PTRMDLG_APP_SEL" resgroup="favorites">
 			<caption xml:lang="en">Apps</caption>
 			<caption xml:lang="de">Apps</caption>
+			<caption xml:lang="nl">Apps</caption>
 			<ctrl text="#l_apps">
 				<c xml:lang="en" helptext="">&amp;Apps::</c>
 				<c xml:lang="de" helptext="">&amp;Apps:</c>
+				<c xml:lang="nl" helptext="">&amp;Apps:</c>
 			</ctrl>
 		</dialog>
 

--- a/imatchres_msg.xml
+++ b/imatchres_msg.xml
@@ -343,6 +343,11 @@
 					<cont>Bei der Migration von Einstellungen von einer älteren IMatch-Version ist ein Problem aufgetreten.\r\n\r\nDie IMatch-Protokolldatei enthält weiterführende Informationen. Bitte machen Sie jetzt eine Kopie dieser Datei über das Hilfe &gt; Support und Menü fügen Sie die Datei der E-Mail an den Support bei.</cont>
 					<ftr></ftr>
 				</m>
+				<m xml:lang="nl">
+					<cap>Kritieke fout - Applicatie-migratie</cap>
+					<cont>Er is een fout opgetreden terwijl IMatch probeerde de instellingen van een oudere IMatch versie te migreren.\r\n\r\nDe IMatch logfile bevat meer informatie. Maak nu een kopie van de logfile via de Help &gt; Ondersteuningsmenu en voeg deze bij aan uw e-mail voor Support.</cont>
+					<ftr></ftr>
+				</m>
 			</msg>
 
 			<!-- Shown when a new ExifTool version is detected and the database needs to update to incorporate the new tag tables -->
@@ -1953,8 +1958,13 @@
 				</m>
 				<m xml:lang="de">
 					<cap>Integrierter Webdienst kann nicht gestartet werden.</cap>
-					<cont xml:lang="de">Der integrierte Webdienst (IMWS) konnte nicht starten. App-basierte Funktionen sind nicht verfügbar.\r\n\r\nHöchstwahrscheinlich wird der unter Bearbeiten &gt; Einstellungen &amp; Anwendung konfigurierte Port bereits von einer anderen Anwendung oder einem Dienst verwenden. Ändern Sie den Port (Erlaubter Breich: 49152 - 65535) und starten Sie IMatch neu.\r\n\r\nTipp: Sie können mit dem Befehl netstat -b in einem Kommandozeilenfenster eine Liste aller verwendeten Ports auf Ihrem Computer abfragen.</cont>
+					<cont xml:lang="de">Der integrierte Webdienst (IMWS) konnte nicht starten. App-basierte Funktionen sind nicht verfügbar.\r\n\r\nHöchstwahrscheinlich wird der unter Bearbeiten &gt; Einstellungen &amp; Anwendung konfigurierte Port bereits von einer anderen Anwendung oder einem Dienst verwenden. Ändern Sie den Port (Erlaubter Bereich: 49152 - 65535) und starten Sie IMatch neu.\r\n\r\nTipp: Sie können mit dem Befehl netstat -b in einem Kommandozeilenfenster eine Liste aller verwendeten Ports auf Ihrem Computer abfragen.</cont>
 					<inf>Die Protokolldatei IMATCH_IMWS_ERRORLOG.TXT im TEMP-Verzeichnis auf Ihrem Computer enthält weitere Informationen. Bitte halten Sie diese Datei bereit, wenn Sie den Support kontaktieren.</inf>
+				</m>
+				<m xml:lang="nl">
+					<cap>Geïntegreerde webserver kan niet worden gestart.</cap>
+					<cont>De geïntegreerde webserver in IMatch (IMWS) kon niet worden gestart. App-gebaseerde functies zijn niet beschikbaar.\r\n\r\nDit probleem wordt hoogstwaarschijnlijk veroorzaakt doordat het aangegeven poortnummer (Bewerken &gt; Voorkeuren &gt; Applicatie) reeds wordt gebruikt door een ander programma of dienst. Probeer het poortnummer te wijzigen (gebruik een nummer in de range van 49152 tot en met 65535) en start IMatch opnieuw.\r\n\r\nTip: U kunt het netstat -b commando vanuit het command prompt window gebruiken om een lijst te zien van alle gebruikte poorten.</cont>
+					<inf>De logfile IMATCH_IMWS_ERRORLOG.TXT in de TEMP map op uw computer bevaat aanvullende informatie. Voeg dit bstand toe als u contact opneemt met support.</inf>
 				</m>
 			</msg>
 
@@ -1968,6 +1978,11 @@
 					<cap>Eine neue IMatch-Version wurde gerade installiert.</cap>
 					<cont xml:lang="de">Jetzt wäre ein guter Zeitpunkt, um sich die Informationen zu den Änderungen und neuen Funktionen anzusehen.\r\n\r\nMöchten Sie die Seite mit den Versionsinformationen jetzt öffnen?</cont>
 					<ftr typeid="[[TD_INFORMATION_ICON]]">Sie können die Versionsinformationen jederzeit über das Hilfe-Menü aufrufen.</ftr>
+				</m>
+				<m xml:lang="nl">
+					<cap>Er is zojuist een nieuwe versie van IMatch geinstalleerd.</cap>
+					<cont>Dit zou een goed moment zijn om de release notes te openen en te bekijken wat er veranderd is en welke nieuwe functies zijn toegevoegd.\r\n\r\nWilt u de pagina met release notes nu openen?</cont>
+					<ftr typeid="[[TD_INFORMATION_ICON]]">U kunt de release notes op iedre gewnest moment openen vanuit het Help menu.</ftr>
 				</m>
 			</msg>
 
@@ -1984,6 +1999,12 @@
 					<cont>Eine oder mehrere Apps sind aktuell nicht bereit, beendet zu werden. Üblicherweise hilft es, ein paar Sekunden zu warten und es dann erneut zu versuchen.</cont>
 					<button btnid="1001">IMatch jetzt nicht beenden</button>
 					<button btnid="1002">IMatch trotzdem beenden</button>
+				</m>
+				<m xml:lang="nl">
+					<cap>Apps worden beëindigd</cap>
+					<cont>Eén of meer apps vragen om Imatch te laten draaien. Normaal helpt het om een paar seconden te wachten en dan opnieuw te proberen IMatch te beëindigen.</cont>
+					<button btnid="1001">IMatch niet nu beëindigen</button>
+					<button btnid="1002">IMatch toch beëindigen</button>
 				</m>
 			</msg>
 
@@ -2687,7 +2708,7 @@
 				</m>
 				<m xml:lang="nl">
 					<cap>Ongeldige databaseversie.</cap>
-					<cont>De database was gecreeerd of geupdate door een nieuwere IMatch-versie en kan niet met deze versie van IMatch worden geopend.\r\n\r\nInstalleer aub de laatste versie van IMatch.</cont>
+					<cont>De database was gecreëerd of geüpdate door een nieuwere IMatch-versie en kan niet met deze versie van IMatch worden geopend.\r\n\r\nInstalleer aub de laatste versie van IMatch.</cont>
 					<inf></inf>
 				</m>
 				<m xml:lang="pt">
@@ -2706,6 +2727,10 @@
 					<cont>Die Datenbank stammt von einer älteren IMatch version und muss aktualisiert werden.\r\n\r\nIMatch kann die Aktualisierung nicht durchführen, wenn die Datenbank im NUR-LESEN Modus geöffnet wird. Bitte öffnen Sie die Datenbank im Schreibmodus oder fragen Sie Ihren Administrator.\r\n\r\nHINWEIS: Die Testversion von IMatch öffnet Datenbanken älter als 30 Tage immer im 'Nur-lesen'-Modus - sie kann keine alten Datenbanken aktualisieren. Sie können aber eine neue Datenbank für Testzwecke anlegen.</cont>
 					<inf></inf>
 				</m>
+				<m xml:lang="nl">
+					<cap>Database moet worden geüpgrade.</cap>
+					<cont>Deze database is gecreëerd door een oudere versie van IMatch version en moet worden geüpgrade om met de huidige versie te kunnen werken.\r\n\r\nIMatch kan dat niet doen als de databse is geopend in "alleen lezen" mode. Open aub de database in "schrijf" mode of vraag uw Administrator.\r\n\r\nNOTE: De testversie van IMatch opent databses die ouder zijn dan 30 dagen altijd in de "alleen-lezen" mode. Zij kan niet worden gebruikt om oude databses te upgraden. U kun een nieuwe databse creëren voor testdoeleinden.</cont>
+				</m>
 			</msg>
 
 			<msg resid="PTR_MSG_NEEDMIGRATION" typeid="[[IDI_QUESTION]]">
@@ -2718,6 +2743,11 @@
 					<cap>Die Datenbank muss aktualisiert werden.</cap>
 					<cont>Die Datenbank stammt von einer älteren IMatch version und muss aktualisiert werden.\r\n\r\nNach der Aktualisierung kann die Datenbank nicht mehr mit älteren IMatch- oder IMatch Anywhere-Versionen genutzt werden. Sie sollten ggf. zuerst eine Sicherungskopie Ihrer Datenbank anlegen.\r\n\r\nMöchten Sie die Datenbank nun öffnen und aktualisieren?</cont>
 					<ftr typeid="[[TD_INFORMATION_ICON]]">Falls Sie gerade ein IMatch-Update installiert haben, ist diese Meldung normal.</ftr>
+				</m>
+				<m xml:lang="nl">
+					<cap>Database moet worden geüpgrade.</cap>
+					<cont>Deze database is gecreëerd door een oudere versie van IMatch version en moet worden geüpgrade om met de huidige versie te kunnen werken.\r\n\r\nNa deze upgarde, kan de database niet langer gebruikt worden met oudere IMatch- of IMatch Anywhere versies. U kunt in voorkomend geval wel een veiligheidskopie van uw database maken. \r\n\r\nWilt u de database nu openen en upgraden?</cont>
+					<ftr typeid="[[TD_INFORMATION_ICON]]">Als u zojuist een IMatch-update heeft geïnstalleerd, is deze melding normaal.</ftr>
 				</m>
 			</msg>
 
@@ -10451,6 +10481,10 @@
 				<m xml:lang="de">
 					<cap>Doppelt vorhande Anwendungs-Id</cap>
 					<cont>Der Anwendungsmanager hat zwei Apps mit der gleichen ID gefunden. Jede App muss über eine eigene appid verfügen.\r\n\r\n{0}\r\n{1}</cont>
+				</m>
+				<m xml:lang="nl">
+					<cap>Dubbele Applicatie ID ontdekt</cap>
+					<cont>De applicatiemanager heeft twee apps gevonden die dezelfde app ID hebben. Iedere App moet een unieke ID hebben.\r\n\r\n{0}\r\n{1}.</cont>
 				</m>
 			</msg>
 

--- a/imatchres_str.xml
+++ b/imatchres_str.xml
@@ -2091,10 +2091,12 @@
 			<str resid="PTR_MAINFRAME_STATUSBAR_DBOPEN_UPGRADE_BEGIN" desc="">
 				<s xml:lang="en">The database is upgraded to version {0}. This can take a while...</s>
 				<s xml:lang="de">Die Datenbank wird auf Version {0} aktualisiert. Dies kann ein wenig dauern...</s>
+				<s xml:lang="nl">De database wordt geügarde naar version {0}. Dit kan even duren...</s>
 			</str>
 			<str resid="PTR_MAINFRAME_STATUSBAR_DBOPEN_UPGRADE_END" desc="">
 				<s xml:lang="en">Database format is current.</s>
 				<s xml:lang="de">Das Datenbankformat ist aktuell.</s>
+				<s xml:lang="nl">Het databaseformat is actueel.</s>
 			</str>
 
 
@@ -2957,6 +2959,7 @@
 			<str resid="PTR_MAINFRAME_CLOSING_APPS">
 				<s xml:lang="en">Closing apps...</s>
 				<s xml:lang="de">Apps werden beendet...</s>
+				<s xml:lang="nl">Apps worden beëindigd...</s>
 			</str>
 
 		</string_group>
@@ -6053,6 +6056,7 @@
 			<str resid="PTR_PANEL_APP_IMWS_NOT_RUNNING">
                 <s xml:lang="en">IMatch WebServices are not running.\r\nPlease enable them under Edit &gt; Preferences &gt; Application and check the configuration.</s>
                 <s xml:lang="de">Die IMatch Webdienste werden nicht ausgeführt.\r\nBitte aktivieren Sie sie unter Bearbeiten &gt; Einstellungen &gt; Anwendung und überprüfen Sie die Konfiguration.</s>
+				<s xml:lang="nl">IMatch WebServices worden niet uitgevoerd.\r\nActiveer ze aub Bewerken &gt; Voorkeuren &gt; Applicatie en controleer de instellingen.</s>
             </str>
             
             <str resid="PTR_PANEL_SCRIPT_IDE" desc="Name for the Script IDE panel">
@@ -7636,6 +7640,7 @@
 			<str resid="FILEWND_CAPTION_DIRECT_FILES">
 				<s xml:lang="en">(Direct assignments only)</s>
 				<s xml:lang="de">(Nur direkt zugewiesene Dateien)</s>
+				<s xml:lang="nl">(Alleen directe toewijzingen)</s>
 			</str>
 
 		</string_group>  <!-- File Window -->
@@ -9901,6 +9906,7 @@
 			<str resid="PTR_FILTERPANEL_HINT">
 				<s xml:lang="en">More filters are available in the 'Gear' menu in the toolbar.</s>
 				<s xml:lang="de">Weitere Filter sind verfügbar über das 'Zahnrad'-Menü in der Symbolleiste.</s>
+				<s xml:lang="nl">Extra filters zijn beschikbaar in het "Instellingen" menu in gereedschapsbalk.</s>
 			</str>
 
 		</string_group>


### PR DESCRIPTION
Translation into Dutch of missing resources in 2017.6.6
They can be incorporated into the next version (2017.6.8)